### PR TITLE
Update PR_GET_FP_MODE and PR_SET_FP_MODE option numbers

### DIFF
--- a/target-mips/cpu.h
+++ b/target-mips/cpu.h
@@ -78,8 +78,8 @@ union wr_t {
 
 #if defined(CONFIG_USER_ONLY)
 /* Custom prctl interface.  */
-#define PR_SET_FP_MODE 43
-#define PR_GET_FP_MODE 44
+#define PR_SET_FP_MODE 45
+#define PR_GET_FP_MODE 46
 #define PR_FP_MODE_FR  (1 << 0)
 #define PR_FP_MODE_FRE (1 << 1)
 #endif


### PR DESCRIPTION
The previous values of these new options have already been used in
upstream kernel sources so the numbers have to increase. A request
is being made to reserve these new numbers while the submission
process takes place.