### PR TITLE
Do not clear BEV for MIPS malta kernel load

### DIFF
--- a/hw/mips/mips_malta.c
+++ b/hw/mips/mips_malta.c
@@ -884,7 +884,7 @@ static void main_cpu_reset(void *opaque)
        read only location. The kernel location and the arguments table
        location does not change. */
     if (loaderparams.kernel_filename) {
-        env->CP0_Status &= ~((1 << CP0St_BEV) | (1 << CP0St_ERL));
+        env->CP0_Status &= ~(1 << CP0St_ERL);
     }
 
     malta_mips_config(cpu);


### PR DESCRIPTION
The BEV flag controls whether the boot exception vector is still
in place when starting a kernel.  When cleared the exception vector
at EBASE (or hard coded address of 0x80000000) is used instead.

The early stages of the linux kernel would benefit from BEV still
being set to ensure any faults get handled by the boot rom exception
handlers.  This is a moot point for system qemu as there aren't really
any BEV handlers, but there are other good reasons to change this...

The UHI (semi-hosting interface) defines special behaviours depending
on whether an application starts in an environment with BEV set or
cleared. When BEV is set then UHI assumes that a bootloader is
relatively dumb and has no advanced exception handling logic.
However, when BEV is cleared then UHI assumes that the bootloader
has the ability to handle UHI exceptions with its exception handlers
and will unwind and forward UHI SYSCALL exceptions to the exception
vector that was installed prior to running the application.