### PR TITLE
target-mips: fix hflags modified in delay / forbidden slot

### DIFF
--- a/target-mips/translate.c
+++ b/target-mips/translate.c
@@ -10893,14 +10893,25 @@ static void gen_rdhwr(DisasContext *ctx, int rt, int rd)
     tcg_temp_free(t0);
 }
 
+static inline void clear_branch_hflags(DisasContext *ctx)
+{
+    ctx->hflags &= ~MIPS_HFLAG_BMASK;
+    if (ctx->bstate == BS_NONE) {
+        save_cpu_state(ctx, 0);
+    } else {
+        /* it is not safe to save ctx->hflags as hflags may be changed
+           in execution time by the instruction in delay / forbidden slot. */
+        tcg_gen_andi_i32(hflags, hflags, ~MIPS_HFLAG_BMASK);
+    }
+}
+
 static void gen_branch(DisasContext *ctx, int insn_bytes)
 {
     if (ctx->hflags & MIPS_HFLAG_BMASK) {
         int proc_hflags = ctx->hflags & MIPS_HFLAG_BMASK;
         /* Branches completion */
-        ctx->hflags &= ~MIPS_HFLAG_BMASK;
+        clear_branch_hflags(ctx);
         ctx->bstate = BS_BRANCH;
-        save_cpu_state(ctx, 0);
         /* FIXME: Need to clear can_do_io.  */
         switch (proc_hflags & MIPS_HFLAG_BMASK_BASE) {
         case MIPS_HFLAG_FBNSLOT:
@@ -10958,8 +10969,8 @@ static void gen_branch(DisasContext *ctx, int insn_bytes)
             tcg_gen_exit_tb(0);
             break;
         default:
-            MIPS_DEBUG("unknown branch");
-            break;
+            fprintf(stderr, "unknown branch 0x%x\n", proc_hflags);
+            abort();
         }
     }
 }


### PR DESCRIPTION
All instructions which may change hflags terminate tb. However, this doesn't
work if such an instruction is placed in delay or forbidden slot.
gen_branch() clears MIPS_HFLAG_BMASK in ctx->hflags and then overwrites hflags,
consequently we loose any execution-time env->hflags modifications.
For example, in the following scenario hflag related to Status.CU1 will not be
updated:
    /* Set Status.CU1 in delay slot */
    mfc0  $24, $12, 0
    lui   $25, 0x2000
    or    $25, $25, $24
    b     check_Status_CU1
    mtc0  $25, $12, 0

With this change we just clear MIPS_HFLAG_BMASK in env->hflags rather than
overwriting it with translation-time ctx->hflags.

Also, die early and loudly if "unknown branch" is encountered as this should
should never happen.

Signed-off-by: Leon Alrae <leon.alrae@imgtec.com>

This fixes #29 issue reported by Markos.