### PR TITLE
Workaround for mfc1 problem

### DIFF
--- a/target-mips/translate.c
+++ b/target-mips/translate.c
@@ -8714,6 +8714,11 @@ static void gen_cp1 (DisasContext *ctx, uint32_t opc, int rt, int fs)
         }
         gen_store_gpr(t0, rt);
         opn = "mfc1";
+#if defined(CONFIG_USER_ONLY)
+        /* Workaround:
+           End tb to avoid TCG optimization with next instruction. */
+        ctx->bstate = BS_STOP;
+#endif
         break;
     case OPC_MTC1:
         gen_load_gpr(t0, rt);


### PR DESCRIPTION
Hi,

Small patch containing the workaround for the issue #32 (Problem with mfc1 emulation) reported by Doug.
The actual bug hasn't been fixed yet (suspecting TCG optimizer). More detailed analysis of the problem can be found:
https://github.com/prplfoundation/qemu/issues/32

Leon