### PR TITLE
HTW: checking config3.pw at the translation time

### DIFF
--- a/target-mips/op_helper.c
+++ b/target-mips/op_helper.c
@@ -1388,52 +1388,45 @@ void helper_mtc0_pagegrain(CPUMIPSState *env, target_ulong arg1)
 
 void helper_mtc0_pwfield(CPUMIPSState *env, target_ulong arg1)
 {
-    if (env->CP0_Config3 & (1 << CP0C3_PW)) {
 #ifdef TARGET_MIPS64
-        env->CP0_PWField = arg1 & 0x3F3FFFFFFFULL;
+    env->CP0_PWField = arg1 & 0x3F3FFFFFFFULL;
 #else
-        {
-            uint32_t mask = 0x3FFFFFFF;
-            uint32_t old_ptei = (env->CP0_PWField >> CP0PF_PTEI) & 0x3F;
-            uint32_t new_ptei = (arg1 >> CP0PF_PTEI) & 0x3F;
-
-            if ((env->insn_flags & ISA_MIPS32R6)) {
-                if (((arg1 >> CP0PF_GDI) & 0x3F) < 12) {
-                    mask &= ~(0x3F << CP0PF_GDI);
-                }
-                if (((arg1 >> CP0PF_UDI) & 0x3F) < 12) {
-                    mask &= ~(0x3F << CP0PF_UDI);
-                }
-                if (((arg1 >> CP0PF_MDI) & 0x3F) < 12) {
-                    mask &= ~(0x3F << CP0PF_MDI);
-                }
-                if (((arg1 >> CP0PF_PTI) & 0x3F) < 12) {
-                    mask &= ~(0x3F << CP0PF_PTI);
-                }
+    {
+        uint32_t mask = 0x3FFFFFFF;
+        uint32_t old_ptei = (env->CP0_PWField >> CP0PF_PTEI) & 0x3F;
+        uint32_t new_ptei = (arg1 >> CP0PF_PTEI) & 0x3F;
+        if ((env->insn_flags & ISA_MIPS32R6)) {
+            if (((arg1 >> CP0PF_GDI) & 0x3F) < 12) {
+                mask &= ~(0x3F << CP0PF_GDI);
             }
-            env->CP0_PWField = arg1 & mask;
-
-            if ((new_ptei >= 32) ||
-                    ((env->insn_flags & ISA_MIPS32R6) &&
-                            (new_ptei == 0 || new_ptei == 1))) {
-                env->CP0_PWField = (env->CP0_PWField & ~0x3F) |
-                        (old_ptei << CP0PF_PTEI);
+            if (((arg1 >> CP0PF_UDI) & 0x3F) < 12) {
+                mask &= ~(0x3F << CP0PF_UDI);
             }
-
+            if (((arg1 >> CP0PF_MDI) & 0x3F) < 12) {
+                mask &= ~(0x3F << CP0PF_MDI);
+            }
+            if (((arg1 >> CP0PF_PTI) & 0x3F) < 12) {
+                mask &= ~(0x3F << CP0PF_PTI);
+            }
         }
-#endif
+        env->CP0_PWField = arg1 & mask;
+        if ((new_ptei >= 32) ||
+                ((env->insn_flags & ISA_MIPS32R6) &&
+                        (new_ptei == 0 || new_ptei == 1))) {
+            env->CP0_PWField = (env->CP0_PWField & ~0x3F) |
+                    (old_ptei << CP0PF_PTEI);
+        }
     }
+#endif
 }
 
 void helper_mtc0_pwsize(CPUMIPSState *env, target_ulong arg1)
 {
-    if (env->CP0_Config3 & (1 << CP0C3_PW)) {
 #ifdef TARGET_MIPS64
-        env->CP0_PWSize = arg1 & 0x3F7FFFFFFFULL;
+    env->CP0_PWSize = arg1 & 0x3F7FFFFFFFULL;
 #else
-        env->CP0_PWSize = arg1 & 0x3FFFFFFF;
+    env->CP0_PWSize = arg1 & 0x3FFFFFFF;
 #endif
-    }
 }
 
 void helper_mtc0_wired(CPUMIPSState *env, target_ulong arg1)
@@ -1474,14 +1467,12 @@ void helper_mtc0_srsconf4(CPUMIPSState *env, target_ulong arg1)
 
 void helper_mtc0_pwctl(CPUMIPSState *env, target_ulong arg1)
 {
-    if (env->CP0_Config3 & (1 << CP0C3_PW)) {
 #ifdef TARGET_MIPS64
-        /* PWEn = 0. Hardware page table walking is not implemented. */
-        env->CP0_PWCtl = (env->CP0_PWCtl & 0x000000C0) | (arg1 & 0x5C00003F);
+    /* PWEn = 0. Hardware page table walking is not implemented. */
+    env->CP0_PWCtl = (env->CP0_PWCtl & 0x000000C0) | (arg1 & 0x5C00003F);
 #else
-        env->CP0_PWCtl = (arg1 & 0x800000FF);
+    env->CP0_PWCtl = (arg1 & 0x800000FF);
 #endif
-    }
 }
 
 void helper_mtc0_hwrena(CPUMIPSState *env, target_ulong arg1)

--- a/target-mips/translate.c
+++ b/target-mips/translate.c
@@ -5289,14 +5289,17 @@ static void gen_mfc0(DisasContext *ctx, TCGv arg, int reg, int sel)
             rn = "PageGrain";
             break;
         case 5:
+            CP0_CHECK(ctx->pw);
             gen_mfc0_load32(arg, offsetof(CPUMIPSState, CP0_PWBase));
             rn = "PWBase";
             break;
         case 6:
+            CP0_CHECK(ctx->pw);
             gen_mfc0_load32(arg, offsetof(CPUMIPSState, CP0_PWField));
             rn = "PWField";
             break;
         case 7:
+            CP0_CHECK(ctx->pw);
             gen_mfc0_load32(arg, offsetof(CPUMIPSState, CP0_PWSize));
             rn = "PWSize";
             break;
@@ -5336,6 +5339,7 @@ static void gen_mfc0(DisasContext *ctx, TCGv arg, int reg, int sel)
             rn = "SRSConf4";
             break;
         case 6:
+            CP0_CHECK(ctx->pw);
             gen_mfc0_load32(arg, offsetof(CPUMIPSState, CP0_PWCtl));
             rn = "PWCtl";
             break;
@@ -5926,16 +5930,17 @@ static void gen_mtc0(DisasContext *ctx, TCGv arg, int reg, int sel)
             ctx->bstate = BS_STOP;
             break;
         case 5:
-            if (ctx->pw) {
-                gen_mtc0_store32(arg, offsetof(CPUMIPSState, CP0_PWBase));
-            }
+            CP0_CHECK(ctx->pw);
+            gen_mtc0_store32(arg, offsetof(CPUMIPSState, CP0_PWBase));
             rn = "PWBase";
             break;
         case 6:
+            CP0_CHECK(ctx->pw);
             gen_helper_mtc0_pwfield(cpu_env, arg);
             rn = "PWField";
             break;
         case 7:
+            CP0_CHECK(ctx->pw);
             gen_helper_mtc0_pwsize(cpu_env, arg);
             rn = "PWSize";
             break;
@@ -5975,6 +5980,7 @@ static void gen_mtc0(DisasContext *ctx, TCGv arg, int reg, int sel)
             rn = "SRSConf4";
             break;
         case 6:
+            CP0_CHECK(ctx->pw);
             gen_helper_mtc0_pwctl(cpu_env, arg);
             rn = "PWCtl";
             break;
@@ -6586,14 +6592,17 @@ static void gen_dmfc0(DisasContext *ctx, TCGv arg, int reg, int sel)
             rn = "PageGrain";
             break;
         case 5:
+            CP0_CHECK(ctx->pw);
             tcg_gen_ld_tl(arg, cpu_env, offsetof(CPUMIPSState, CP0_PWBase));
             rn = "PWBase";
             break;
         case 6:
+            CP0_CHECK(ctx->pw);
             tcg_gen_ld_tl(arg, cpu_env, offsetof(CPUMIPSState, CP0_PWField));
             rn = "PWField";
             break;
         case 7:
+            CP0_CHECK(ctx->pw);
             tcg_gen_ld_tl(arg, cpu_env, offsetof(CPUMIPSState, CP0_PWSize));
             rn = "PWSize";
             break;
@@ -6633,6 +6642,7 @@ static void gen_dmfc0(DisasContext *ctx, TCGv arg, int reg, int sel)
             rn = "SRSConf4";
             break;
         case 6:
+            CP0_CHECK(ctx->pw);
             gen_mfc0_load32(arg, offsetof(CPUMIPSState, CP0_PWCtl));
             rn = "PWCtl";
             break;
@@ -7214,16 +7224,17 @@ static void gen_dmtc0(DisasContext *ctx, TCGv arg, int reg, int sel)
             rn = "PageGrain";
             break;
         case 5:
-            if (ctx->pw) {
-                tcg_gen_st_tl(arg, cpu_env, offsetof(CPUMIPSState, CP0_PWBase));
-            }
+            CP0_CHECK(ctx->pw);
+            tcg_gen_st_tl(arg, cpu_env, offsetof(CPUMIPSState, CP0_PWBase));
             rn = "PWBase";
             break;
         case 6:
+            CP0_CHECK(ctx->pw);
             gen_helper_mtc0_pwfield(cpu_env, arg);
             rn = "PWField";
             break;
         case 7:
+            CP0_CHECK(ctx->pw);
             gen_helper_mtc0_pwsize(cpu_env, arg);
             rn = "PWSize";
             break;
@@ -7263,6 +7274,7 @@ static void gen_dmtc0(DisasContext *ctx, TCGv arg, int reg, int sel)
             rn = "SRSConf4";
             break;
         case 6:
+            CP0_CHECK(ctx->pw);
             gen_helper_mtc0_pwctl(cpu_env, arg);
             rn = "PWCtl";
             break;


### PR DESCRIPTION
No real functional changes but as config3.pw bit is known at the translation time,
no reason to defer to check it to the helper.

Signed-off-by: Yongbok Kim <yongbok.kim@imgtec.com>