### PR TITLE
target-mips: Fix Misaligned accesses, RI for unimplemented Paired Single

### DIFF
--- a/target-mips/helper.c
+++ b/target-mips/helper.c
@@ -758,6 +758,9 @@ bool cpu_mips_validate_access(CPUMIPSState *env, target_ulong address,
     ret = get_physical_address(env, &physical, &prot,
             addr, rw, access_type);
     if (ret != TLBRET_MATCH) {
+        if (ret != TLBRET_BADADDR && addr > badvaddr) {
+            badvaddr = addr;
+        }
         raise_mmu_exception(env, badvaddr, rw, ret);
         return false;
     }


### PR DESCRIPTION
target-mips: fix updating BadVAddr for misaligned accesses
target-mips: raise RI exceptions when FIR.PS = 0

Signed-off-by: Yongbok Kim <yongbok.kim@imgtec.com>