### PR TITLE
linux-user: Use abi_ulong for TARGET_ELF_PAGESTART

### DIFF
--- a/linux-user/elfload.c
+++ b/linux-user/elfload.c
@@ -1248,7 +1248,8 @@ struct exec
 
 /* Necessary parameters */
 #define TARGET_ELF_EXEC_PAGESIZE TARGET_PAGE_SIZE
-#define TARGET_ELF_PAGESTART(_v) ((_v) & ~(unsigned long)(TARGET_ELF_EXEC_PAGESIZE-1))
+#define TARGET_ELF_PAGESTART(_v) ((_v) & \
+                                 ~(abi_ulong)(TARGET_ELF_EXEC_PAGESIZE-1))
 #define TARGET_ELF_PAGEOFFSET(_v) ((_v) & (TARGET_ELF_EXEC_PAGESIZE-1))
 
 #define DLINFO_ITEMS 14


### PR DESCRIPTION
TARGET_ELF_PAGESTART is required to use abi_ulong to correctly handle
addresses for different target bits width.
This patch fixes a problem when running a 64-bit user mode application
on 32-bit host machines.

Signed-off-by: Yongbok Kim <yongbok.kim@imgtec.com>
Reviewed-by: Peter Maydell <peter.maydell@linaro.org>