### PR TITLE
Fix N64 trap and break instruction bug in linux-user mode.

### DIFF
--- a/linux-user/main.c
+++ b/linux-user/main.c
@@ -2580,7 +2580,7 @@ done_syscall:
                         code = (trap_instr >> 6) & 0x3f;
                     }
                 } else {
-                    ret = get_user_ual(trap_instr, env->active_tc.PC);
+                    ret = get_user_u32(trap_instr, env->active_tc.PC);
                     if (ret != 0) {
                         goto error;
                     }
@@ -2614,7 +2614,7 @@ done_syscall:
 
                     trap_instr = (instr[0] << 16) | instr[1];
                 } else {
-                    ret = get_user_ual(trap_instr, env->active_tc.PC);
+                    ret = get_user_u32(trap_instr, env->active_tc.PC);
                 }
 
                 if (ret != 0) {


### PR DESCRIPTION
For the N64 ABI when QEMU reads the break/trap instruction so that
it can inspect the break/trap code it reads 8 rather than 4 bytes
which means it finds the the code field from the instruction after
the break/trap instruction.  This then causes the break/trap handling
code to fail because it does not understand the code number.

The fix forces QEMU to always read 4 bytes of instruction data rather
than deciding how much to read based on the ABI.